### PR TITLE
Make CloudDeploy resulting class inmutable

### DIFF
--- a/lib/CloudFormation/DSL/Object.pm
+++ b/lib/CloudFormation/DSL/Object.pm
@@ -110,6 +110,8 @@ package CloudFormation::DSL::Object {
         }
       }
     }
+
+    $class_meta->make_immutable
   }
 
   sub get_stackversion_from_metadata {

--- a/t/128_make_immutable.t
+++ b/t/128_make_immutable.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+
+package TestClass {
+  use CloudFormation::DSL;
+}
+
+{
+    my $obj = TestClass->new();    
+    throws_ok( sub { $obj->meta()->add_attribute( '__test_attribute', is=>'ro') }, qr/The 'add_attribute' method cannot be called on an immutable instance/,
+        'class is inmutable');
+}
+
+done_testing();


### PR DESCRIPTION
Making class immutable prevents the developer from modifying class definition after is read by `BUILD` method.