### PR TITLE
Namespace autoclean

### DIFF
--- a/lib/CloudFormation/DSL.pm
+++ b/lib/CloudFormation/DSL.pm
@@ -4,6 +4,7 @@ package CloudFormation::DSL {
   use Moose ();
   use Moose::Exporter;
   use Moose::Util::MetaRole ();
+  use namespace::autoclean ();
 
   our $VERSION = '0.01';
   # ABSTRACT: A DSL for building CloudFormation templates
@@ -32,6 +33,10 @@ package CloudFormation::DSL {
                   GetASGStatus GetInstanceStatus FindUbuntuImage FindBaseImage SpecifyInSubClass/ ],
       also  => 'Moose',
     );
+    namespace::autoclean->import(
+      -cleanee => scalar(caller),
+    );
+
     goto &$import;
   }
 

--- a/t/127_namespace_autoclean.t
+++ b/t/127_namespace_autoclean.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More;
+
+{
+    package TestClass;
+    sub bar { }
+    use CloudFormation::DSL;
+    sub moo { }
+    BEGIN { *kooh = *kooh = do { package Moose; sub { }; }; }
+    BEGIN { *affe = *affe = sub { }; }
+}
+ 
+ok( TestClass->can('bar'), 'TestClass can bar - standard method');
+ok( TestClass->can('moo'), 'TestClass can moo - standard method');
+ok(!TestClass->can('kooh'), 'TestClass cannot kooh - anon sub from another package assigned to glob');
+ok( TestClass->can('affe'), 'TestClass can affe - anon sub assigned to glob in package');
+ 
+done_testing();
+


### PR DESCRIPTION
This feature uses [namespace::autoclean](https://metacpan.org/pod/namespace::autoclean) to keep imports out of `CloudDeploy::DSL` namespace.