### PR TITLE
Ensure that package returns true

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -7,6 +7,7 @@ requires 'DateTime::Format::Strptime';
 requires 'LWP::Simple';
 requires 'JSON::MaybeXS';
 requires 'Hash::AsObject';
+requires 'true';
 
 on test => sub {
   requires 'Test::More';

--- a/lib/CloudFormation/DSL.pm
+++ b/lib/CloudFormation/DSL.pm
@@ -20,14 +20,20 @@ package CloudFormation::DSL {
 
   our $ubuntu_release_table_url = 'https://cloud-images.ubuntu.com/locator/ec2/releasesTable';
 
-  Moose::Exporter->setup_import_methods(
-    with_meta => [ 'parameter', 'attachment', 'resource', 'output', 'condition', 
-                   'mapping', 'metadata', 'stack_version', 'transform' ],
-    as_is => [ qw/Ref ConditionRef GetAtt UserData CfString Parameter Attribute Json
-                Tag ELBListener TCPELBListener SGRule SGEgressRule 
-                GetASGStatus GetInstanceStatus FindUbuntuImage FindBaseImage SpecifyInSubClass/ ],
-    also  => 'Moose',
-  );
+  # import method is used to export functions provided by
+  # packages that doesn't uses Moose::Exporter 
+  sub import {
+    my ($import) = Moose::Exporter->build_import_methods(
+      install => [ 'unimport' ],
+      with_meta => [ 'parameter', 'attachment', 'resource', 'output', 'condition', 
+                    'mapping', 'metadata', 'stack_version', 'transform' ],
+      as_is => [ qw/Ref ConditionRef GetAtt UserData CfString Parameter Attribute Json
+                  Tag ELBListener TCPELBListener SGRule SGEgressRule 
+                  GetASGStatus GetInstanceStatus FindUbuntuImage FindBaseImage SpecifyInSubClass/ ],
+      also  => 'Moose',
+    );
+    goto &$import;
+  }
 
   # init_meta is used to make whoever uses CloudFormation::DSL to be a subclass
   # of CloudFormation::DSL::Object

--- a/lib/CloudFormation/DSL.pm
+++ b/lib/CloudFormation/DSL.pm
@@ -4,6 +4,7 @@ package CloudFormation::DSL {
   use Moose ();
   use Moose::Exporter;
   use Moose::Util::MetaRole ();
+  use true ();
 
   our $VERSION = '0.01';
   # ABSTRACT: A DSL for building CloudFormation templates
@@ -32,6 +33,8 @@ package CloudFormation::DSL {
                   GetASGStatus GetInstanceStatus FindUbuntuImage FindBaseImage SpecifyInSubClass/ ],
       also  => 'Moose',
     );
+    true->import();
+
     goto &$import;
   }
 

--- a/t/126_true.t
+++ b/t/126_true.t
@@ -7,7 +7,9 @@ use lib "$Bin/126_true";
 
 BEGIN { 
     use_ok('TestTrue');
+    use_ok('TestTrueCurly');
     use_ok('TestNonTrue');
+    use_ok('TestNonTrueCurly');
 }
 
 done_testing();

--- a/t/126_true.t
+++ b/t/126_true.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use FindBin qw($Bin);
+use lib "$Bin/126_true";
+
+BEGIN { 
+    use_ok('TestTrue');
+    use_ok('TestNonTrue');
+}
+
+done_testing();

--- a/t/126_true/TestNonTrue.pm
+++ b/t/126_true/TestNonTrue.pm
@@ -1,0 +1,4 @@
+package TestNonTrue;
+use CloudFormation::DSL;
+
+# This package should return 1

--- a/t/126_true/TestNonTrueCurly.pm
+++ b/t/126_true/TestNonTrueCurly.pm
@@ -1,0 +1,5 @@
+package TestNonTrueCurly {
+  use CloudFormation::DSL;
+
+  # This package should return 1
+}

--- a/t/126_true/TestTrue.pm
+++ b/t/126_true/TestTrue.pm
@@ -1,0 +1,4 @@
+package TestTrue;
+use CloudFormation::DSL;
+
+1;

--- a/t/126_true/TestTrueCurly.pm
+++ b/t/126_true/TestTrueCurly.pm
@@ -1,0 +1,5 @@
+package TestTrue {
+  use CloudFormation::DSL;
+
+}
+1;


### PR DESCRIPTION
Perl's `require` builtin (and its `use` wrapper) requires the files it loads to return a true value. This is magically accomplished by using [true](https://metacpan.org/pod/true) package