### PR TITLE
Fix POD errors in readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cpanfile.snapshot
 local/
 dzil-local/
+CloudFormation-DSL-*

--- a/README.md
+++ b/README.md
@@ -328,8 +328,8 @@ is a shorthand way of writing an ELB Listener. It can be used in many ways:
 `ELBListener(80, 'HTTP', 3000)` will forward traffic from port 80 of the ELB to port 3000 on the 
 backends
 
-`ELBListener(443, 'HTTPS', 5000, 'HTTP') will do SSL offloading on the ELB, forwarding to port 
-5000 HTTP on the backends`
+`ELBListener(443, 'HTTPS', 5000, 'HTTP')` will do SSL offloading on the ELB, forwarding to port 
+5000 HTTP on the backends
 
 ## TCPELBListener($lbport\[, $instance\_port\])
 
@@ -426,11 +426,3 @@ Please report bugs to: [https://github.com/pplu/cfn-perl/cloudformation-dsl](htt
 Copyright (c) 2013 by CAPSiDE
 This code is distributed under the Apache 2 License. The full text of the 
 license can be found in the LICENSE file included with this module.
-
-# POD ERRORS
-
-Hey! **The above document had some coding errors, which are explained below:**
-
-- Around line 990:
-
-    Unterminated C<...> sequence

--- a/cpanfile
+++ b/cpanfile
@@ -14,4 +14,5 @@ on test => sub {
   requires 'Test::Exception';
   requires 'Data::Printer';
   requires 'Test::Trap';
+  requires 'Test::File::Contents';
 };

--- a/cpanfile
+++ b/cpanfile
@@ -15,4 +15,5 @@ on test => sub {
   requires 'Data::Printer';
   requires 'Test::Trap';
   requires 'Test::File::Contents';
+  requires 'Test::Pod';
 };

--- a/lib/CloudFormation/DSL.pm
+++ b/lib/CloudFormation/DSL.pm
@@ -1014,7 +1014,7 @@ C<ELBListener(80, 'HTTP')> will forward traffic from port 80 of the ELB to port 
 C<ELBListener(80, 'HTTP', 3000)> will forward traffic from port 80 of the ELB to port 3000 on the 
 backends
 
-C<ELBListener(443, 'HTTPS', 5000, 'HTTP') will do SSL offloading on the ELB, forwarding to port 
+C<ELBListener(443, 'HTTPS', 5000, 'HTTP')> will do SSL offloading on the ELB, forwarding to port 
 5000 HTTP on the backends
 
 =head2 TCPELBListener($lbport[, $instance_port])

--- a/t/129_dist.t
+++ b/t/129_dist.t
@@ -1,0 +1,6 @@
+use Test::More;
+use Test::File::Contents;
+
+file_contents_unlike 'README.md', qr/^# POD ERRORS$/m, "README file doesn't contains POD errors";
+
+done_testing();

--- a/t/129_pod.t
+++ b/t/129_pod.t
@@ -1,6 +1,8 @@
 use Test::More;
+use Test::Pod;
 use Test::File::Contents;
 
+pod_file_ok ('lib/CloudFormation/DSL.pm', 'CloudFormation/DSL.pm contains valid POD');
 file_contents_unlike 'README.md', qr/^# POD ERRORS$/m, "README file doesn't contains POD errors";
 
 done_testing();


### PR DESCRIPTION
Removes POD errors in README

```
POD ERRORS

Hey! The above document had some coding errors, which are explained below:

    Around line 990:

    Unterminated C<...> sequence
```