### PR TITLE
Add missing CloudFormation functions

### DIFF
--- a/lib/AWS.pm
+++ b/lib/AWS.pm
@@ -20,4 +20,10 @@ package AWS;
   sub StackName {
     return { Ref => 'AWS::StackName' };
   }
+  sub Partition {
+    return { Ref => 'AWS::Partition' };
+  }
+  sub URLSuffix {
+    return { Ref => 'AWS::URLSuffix' };
+  }
 1;

--- a/lib/CloudFormation/DSL.pm
+++ b/lib/CloudFormation/DSL.pm
@@ -442,9 +442,7 @@ package CloudFormation::DSL {
   }
 
   sub GetAtt {
-    my ($ref, $property) = @_;
-    die "GetAtt expected a logical name and a property name" if (not defined $ref or not defined $property);
-    { 'Fn::GetAtt' => [ $ref, $property ] }
+    return Fn::GetAtt(@_);
   }
 
   sub ELBListener {

--- a/lib/Fn.pm
+++ b/lib/Fn.pm
@@ -95,5 +95,11 @@ package Fn;
     return { 'Fn::And' => [ @conditions ] };
   }
 
+  sub GetAtt {
+    my ($ref, $property) = @_;
+    die "Fn::GetAtt expected a logical name and a property name" if (not defined $ref or not defined $property);
+    { 'Fn::GetAtt' => [ $ref, $property ] }
+  }
+
 1;
 

--- a/lib/Fn.pm
+++ b/lib/Fn.pm
@@ -90,5 +90,10 @@ package Fn;
     }
   }
 
+  sub And {
+    my @conditions = @_;
+    return { 'Fn::And' => [ @conditions ] };
+  }
+
 1;
 

--- a/t/110_fn_namespace.t
+++ b/t/110_fn_namespace.t
@@ -34,4 +34,16 @@ is_deeply(
   'And used as Function'
 );
 
+is_deeply(
+  Fn::GetAtt( 'ref' , 'property' ),
+  { 'Fn::GetAtt' => [ 'ref', 'property' ] },
+  'GetAtt used as Function'
+);
+
+is_deeply(
+  GetAtt( 'ref' , 'property' ),
+  Fn::GetAtt( 'ref' , 'property' ),
+  'GetAtt should return the same result as Fn::GetAtt'
+);
+
 done_testing;

--- a/t/110_fn_namespace.t
+++ b/t/110_fn_namespace.t
@@ -28,4 +28,10 @@ is_deeply(
   { 'Fn::Cidr' => [ '1.1.1.1', 2 ] }
 );
 
+is_deeply(
+  Fn::And( 'val1' , 'val2' ),
+  { 'Fn::And' => [ 'val1', 'val2' ] },
+  'And used as Function'
+);
+
 done_testing;

--- a/t/130_aws_namespace.t
+++ b/t/130_aws_namespace.t
@@ -1,11 +1,11 @@
 use Test::More;
 use AWS;
 
-foreach my $thing ( keys %AWS:: ) {
+my @pseudoparams = qw/AccountId Partition NotificationARNs StackName StackId Region URLSuffix NoValue/;
+
+foreach my $thing ( @pseudoparams ) {
   my $sub = *{ "AWS::$thing" };
-  if ( defined &$sub ) {    
-    is_deeply ( &$sub , { 'Ref' => "AWS::$thing" }, "AWS::$thing" );
-  }
+  is_deeply ( &$sub , { 'Ref' => "AWS::$thing" }, "AWS::$thing" );
 }
 
 

--- a/t/130_aws_namespace.t
+++ b/t/130_aws_namespace.t
@@ -1,0 +1,12 @@
+use Test::More;
+use AWS;
+
+foreach my $thing ( keys %AWS:: ) {
+  my $sub = *{ "AWS::$thing" };
+  if ( defined &$sub ) {    
+    is_deeply ( &$sub , { 'Ref' => "AWS::$thing" }, "AWS::$thing" );
+  }
+}
+
+
+done_testing();


### PR DESCRIPTION
Add followinfg functions

- `Fn::And`
- `Fn:GetAtt`
- `AWS::Partition`
- `AWS::URLSuffix`

Also `CloudFormation::DSL::GetAtt` is mapped to  `Fn:GetAtt` to maintain CloudFormation naming conventions.

